### PR TITLE
Adds a white background and rounds corners on sponsor logos

### DIFF
--- a/source/assets/css/style.css.sass
+++ b/source/assets/css/style.css.sass
@@ -44,6 +44,11 @@
   padding: 15%
 
 img.sponsor-img
+  background-color: #fff
+  border-radius: 5px
+  padding: 5px
+  margin: 1px
+
   &.level-ohio
     width: 100%
   &.level-allegheny


### PR DESCRIPTION
Just affects the sponsorship page, not the page with descriptions.

Here's what it looks like:
![sponsors steel city ruby conf 2014 august 15-16](https://cloud.githubusercontent.com/assets/197224/3141990/32e56078-e9a4-11e3-8d23-cfefa8cbfb18.png)

I'm mixed on it. Thoughts?
